### PR TITLE
chore: updated the url of eternalempires

### DIFF
--- a/data/companies.toml
+++ b/data/companies.toml
@@ -386,7 +386,7 @@ logo = "bosach.png"
 
 [companies.eternal_empires]
 name = "Eternal Empires"
-home = "https://github.com/EternalEmpires"
+home = "https://eternalempires.net/"
 logo = "eternalempires.png"
 
 [companies.oktopus]


### PR DESCRIPTION
This pull request includes a small change to the `data/companies.toml` file. The change updates the homepage URL for the "Eternal Empires" company. 

* [`data/companies.toml`](diffhunk://#diff-8bf399ab5202f09eec8be18bf94ed465777ea14afc28c8fb164a5536b09f9623L389-R389): Updated the homepage URL for "Eternal Empires" from "https://github.com/EternalEmpires" to "https://eternalempires.net/".